### PR TITLE
Main branch renamed to `main`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,14 +36,14 @@ None.
 
 [1]: https://img.shields.io/crates/v/path-table.svg?style=flat-square
 [2]: https://crates.io/crates/path-table
-[3]: https://img.shields.io/travis/rustasync/path-table/master.svg?style=flat-square
-[4]: https://travis-ci.org/rustasync/path-table
+[3]: https://img.shields.io/travis/http-rs/path-table/main.svg?style=flat-square
+[4]: https://travis-ci.org/http-rs/path-table
 [5]: https://img.shields.io/crates/d/path-table.svg?style=flat-square
 [6]: https://crates.io/crates/path-table
 [7]: https://img.shields.io/badge/docs-latest-blue.svg?style=flat-square
 [8]: https://docs.rs/path-table
 
-[releases]: https://github.com/rustasync/path-table/releases
-[contributing]: https://github.com/rustasync/path-table/blob/master/.github/CONTRIBUTING.md
-[good-first-issue]: https://github.com/rustasync/path-table/labels/good%20first%20issue
-[help-wanted]: https://github.com/rustasync/path-table/labels/help%20wanted
+[releases]: https://github.com/http-rs/path-table/releases
+[contributing]: https://github.com/http-rs/path-table/blob/main/.github/CONTRIBUTING.md
+[good-first-issue]: https://github.com/http-rs/path-table/labels/good%20first%20issue
+[help-wanted]: https://github.com/http-rs/path-table/labels/help%20wanted


### PR DESCRIPTION
Per https://github.com/http-rs/surf/issues/211, all the main branch names in the http-rs org have been changed to `main`. This PR updates the references from the old name and hopefully also serves as a notification for contributors! If there is any more fallout, please @ me and I'll do my best to deal with it.